### PR TITLE
Print shopify_api (ActiveResource) warnings to STDOUT

### DIFF
--- a/lib/shopify_cli/cli.rb
+++ b/lib/shopify_cli/cli.rb
@@ -106,6 +106,10 @@ module ShopifyCLI
       puts "using #{config['domain']}"
       ShopifyAPI::Base.site = site_from_config(config)
 
+      logger = Logger.new(STDOUT)
+      logger.level = Logger::WARN
+      ActiveResource::Base.logger = logger
+
       launch_shell(config)
     end
 


### PR DESCRIPTION
Related to https://github.com/Shopify/shopify_api/pull/498

Since Shopify will now consistently return deprecation warning response headers, this change ensures that warnings seen by the shopify_api gem are printed to the console, for anyone using shopify_cli to see.