### PR TITLE
Add API Versioning support

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,8 +11,8 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (5.2.2)
-      activesupport (= 5.2.2)
+    activemodel (5.2.3)
+      activesupport (= 5.2.3)
     activemodel-serializers-xml (1.0.2)
       activemodel (> 5.x)
       activesupport (> 5.x)
@@ -21,33 +21,33 @@ GEM
       activemodel (>= 5.0, < 7)
       activemodel-serializers-xml (~> 1.0)
       activesupport (>= 5.0, < 7)
-    activesupport (5.2.2)
+    activesupport (5.2.3)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
     builder (3.2.3)
     coderay (1.1.2)
-    concurrent-ruby (1.1.3)
+    concurrent-ruby (1.1.5)
     fakeweb (1.3.0)
-    graphql (1.8.11)
+    graphql (1.9.4)
     graphql-client (0.14.0)
       activesupport (>= 3.0, < 6.0)
       graphql (~> 1.6)
-    i18n (1.1.1)
+    i18n (1.6.0)
       concurrent-ruby (~> 1.0)
     metaclass (0.0.4)
     method_source (0.9.2)
-    minitest (5.7.0)
+    minitest (5.11.3)
     mocha (1.1.0)
       metaclass (~> 0.0.1)
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
-    rack (2.0.6)
+    rack (2.0.7)
     rake (10.4.2)
-    shopify_api (5.2.0)
-      activeresource (>= 3.0.0)
+    shopify_api (7.0.1)
+      activeresource (>= 4.1.0, < 6.0.0)
       graphql-client
       rack
     thor (0.18.1)
@@ -66,4 +66,4 @@ DEPENDENCIES
   shopify_cli!
 
 BUNDLED WITH
-   1.16.3
+   1.17.3

--- a/lib/shopify_cli/cli.rb
+++ b/lib/shopify_cli/cli.rb
@@ -31,6 +31,8 @@ module ShopifyCLI
         puts "\nopen https://#{config['domain']}/admin/apps/private in your browser to create a private app and get API credentials\n"
         config['api_key']  = ask("API key?")
         config['password'] = ask("Password?")
+        config['version']  = ask("API Version? (leave blank for '2019-04')")
+        config['version']   = "2019-04" if config['version'].blank?
         if ask("Would you like to use pry as your shell? (y/n)") === "y"
           config["shell"] = "pry"
         else
@@ -140,7 +142,9 @@ module ShopifyCLI
       api_key  = config['api_key']
       password = config['password']
       domain   = config['domain']
+      version   = config['version']
 
+      ShopifyAPI::Base.api_version = version
       ShopifyAPI::Base.site = "#{protocol}://#{api_key}:#{password}@#{domain}/admin"
     end
 

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -27,7 +27,7 @@ class CliTest < Minitest::Test
 
   test "add with blank domain" do
     standard_add_shop_prompts
-    $stdin.expects(:gets).times(4).returns("", "key", "pass", "y")
+    $stdin.expects(:gets).times(5).returns("", "key", "pass", '', "y")
     @cli.expects(:puts).with("\nopen https://foo.myshopify.com/admin/apps/private in your browser to create a private app and get API credentials\n")
     @cli.expects(:puts).with("Default connection is foo")
 
@@ -44,7 +44,7 @@ class CliTest < Minitest::Test
 
   test "add with explicit domain" do
     standard_add_shop_prompts
-    $stdin.expects(:gets).times(4).returns("bar.myshopify.com", "key", "pass", "y")
+    $stdin.expects(:gets).times(5).returns("bar.myshopify.com", "key", "pass", "", "y")
     @cli.expects(:puts).with("\nopen https://bar.myshopify.com/admin/apps/private in your browser to create a private app and get API credentials\n")
     @cli.expects(:puts).with("Default connection is foo")
 
@@ -56,7 +56,7 @@ class CliTest < Minitest::Test
 
   test "add with irb as shell" do
     standard_add_shop_prompts
-    $stdin.expects(:gets).times(4).returns("bar.myshopify.com", "key", "pass", "fuuuuuuu")
+    $stdin.expects(:gets).times(5).returns("bar.myshopify.com", "key", "pass", '', "fuuuuuuu")
     @cli.expects(:puts).with("\nopen https://bar.myshopify.com/admin/apps/private in your browser to create a private app and get API credentials\n")
     @cli.expects(:puts).with("Default connection is foo")
 
@@ -127,6 +127,7 @@ class CliTest < Minitest::Test
     $stdout.expects(:print).with("API key? ")
     $stdout.expects(:print).with("Password? ")
     $stdout.expects(:print).with("Would you like to use pry as your shell? (y/n) ")
+    $stdout.expects(:print).with("API Version? (leave blank for '2019-04') ")
   end
 
   def force_remove(pattern)


### PR DESCRIPTION
Adds a config option for setting the API Version. Closes #7 

for review @Shopify/platform-dev-tools-education 